### PR TITLE
fix(website): bind identifiers to their name by document structure

### DIFF
--- a/src/scrapers/apple-website-scraper.ts
+++ b/src/scrapers/apple-website-scraper.ts
@@ -82,48 +82,96 @@ export class AppleWebsiteScraper {
   }
 
   private _parseDevicesFromDocument(document: HTMLDocument): Device[] {
-    const names = this._parseNamesFrom(document);
-    const ids = this._parseIdsFrom(document);
-    if (names.length !== ids.length) {
-      throw new Error(
-        `names and ids are not matched. names: ${names.length}, ids: ${ids.length}`,
-      );
+    // "MacBook" is the only page still using the old layout as of 2024
+    const isRenewed = this._isRenewedWebsite(document);
+    if (!isRenewed) {
+      console.log('[DEBUG] old website detected');
     }
 
-    const devices = names.map((name, i) => {
-      const id = ids[i];
-      return id.map((id) => ({ id, name }));
-    }).flat();
+    const devices = isRenewed
+      ? this._parseDevicesFromSections(document)
+      : this._parseDevicesFromParagraphs(document);
+
+    // an empty result means the layout changed in a way we no longer understand,
+    // so fail loudly instead of silently wiping the existing identifiers
+    if (devices.length === 0) {
+      throw new Error('no devices found. the website layout may have changed.');
+    }
 
     return devices;
   }
 
-  private _parseNamesFrom(document: HTMLDocument): string[] {
-    const names = this._parseTextsFrom(document, 'p.gb-paragraph b');
-
-    // if there's a colon at the end of these field, it's 2024 renewed website
-    // so we need to parse names in new way
-    const is2024Renewed = names.some((name) =>
-      name.endsWith(':') || name.endsWith('：') // japanese colon
-    );
-    if (is2024Renewed) {
-      const names = this._parseTextsFrom(document, 'h2.gb-header')
-        .filter((text) => text.includes('Mac')); // "Learn More" added on MacPro website
-      return names;
-    } else {
-      // 2024 currently, only "MacBook" has old website
-      console.log('[DEBUG] old website detected');
-    }
-
-    return names;
+  private _isRenewedWebsite(document: HTMLDocument): boolean {
+    // the 2024 renewed website labels every field with a bold text ending
+    // with a colon, e.g. "Model Identifier:"
+    return this._parseTextsFrom(document, 'p.gb-paragraph b')
+      .some((text) => text.endsWith(':') || text.endsWith('：')); // japanese colon
   }
 
-  private _parseIdsFrom(document: HTMLDocument): string[][] {
-    const ids = this._parseTextsFrom(document, 'p.gb-paragraph')
-      .map((text) => text.match(/[A-Za-z]+\d+,\d+/g))
-      .filter((match) => match) as string[][];
+  /**
+   * The renewed website puts a device name in a heading and its identifiers in
+   * the paragraphs below it, so we walk the document in order and bind each
+   * paragraph to the nearest heading above it. Headings that own no identifier
+   * (e.g. "Learn more") simply contribute no device.
+   */
+  private _parseDevicesFromSections(document: HTMLDocument): Device[] {
+    const devices: Device[] = [];
+    let name: string | undefined;
 
-    return ids;
+    for (
+      const node of document.querySelectorAll('h2.gb-header, p.gb-paragraph')
+    ) {
+      const text = node.textContent.trim();
+
+      if (node.localName === 'h2') {
+        name = text;
+        continue;
+      }
+
+      // paragraphs before the first heading belong to no device
+      if (name === undefined) continue;
+
+      const deviceName = name;
+      for (const id of this._parseIdsFrom(text)) {
+        devices.push({ id, name: deviceName });
+      }
+    }
+
+    return devices;
+  }
+
+  /**
+   * The old website has no heading per device: a paragraph holding nothing but
+   * a bold text names the device, and the paragraphs after it carry its
+   * identifiers. So we walk the paragraphs and bind them the same way.
+   */
+  private _parseDevicesFromParagraphs(document: HTMLDocument): Device[] {
+    const devices: Device[] = [];
+    let name: string | undefined;
+
+    for (const paragraph of document.querySelectorAll('p.gb-paragraph')) {
+      const text = paragraph.textContent.trim();
+      const bold = paragraph.querySelector('b')?.textContent.trim();
+
+      if (bold && bold === text) {
+        name = bold;
+        continue;
+      }
+
+      // paragraphs before the first name belong to no device
+      if (name === undefined) continue;
+
+      const deviceName = name;
+      for (const id of this._parseIdsFrom(text)) {
+        devices.push({ id, name: deviceName });
+      }
+    }
+
+    return devices;
+  }
+
+  private _parseIdsFrom(text: string): string[] {
+    return text.match(/[A-Za-z]+\d+,\d+/g) ?? [];
   }
 
   private _parseTextsFrom(


### PR DESCRIPTION
## Why

`Scrap from Apple` has failed every week since run #197 (2026-07-06); run #196 (2026-06-29) was the last success. The code never changed in between — Apple's pages did.

Apple added a **"Find the name of your Mac model"** heading to the top of every renewed support page. `_parseNamesFrom` kept headings containing `Mac`, so this one passed the filter and the name list grew by one while the identifier list did not:

```
error: Uncaught (in promise) Error: names and ids are not matched. names: 7, ids: 6
    at AppleWebsiteScraper._parseDevicesFromDocument (apple-website-scraper.ts:88:13)
    at async Promise.all (index 5)   // MAC_IDS[5] = MacStudio (102231)
```

Because `loadDevicesFromUrls` uses `Promise.all`, one page aborted all 7 products × 7 locales. All six renewed pages are affected (`names = ids + 1` on every one); only the MacBook page, still on the old layout, kept parsing.

The count check was also a weak guard rather than a real invariant: once Apple adds a seventh Mac Studio model the counts match again, and the index pairing would then have shifted every name by one silently.

## What

Walk the document in order and bind each paragraph to the name above it, so a device name and its identifiers are associated by document structure rather than by position.

- **Renewed layout** — an `h2.gb-header` names the devices below it. A heading that owns no identifier contributes no device, which retires the `includes('Mac')` filter that was working around this same problem on the Mac Pro page.
- **Old layout** — there is no per-device heading; a paragraph holding nothing but a bold text names the device, and the paragraphs after it carry its identifiers:
  ```html
  <p class="gb-paragraph"><b>MacBook (Retina, 12-inch, 2017)</b></p>
  <p class="gb-paragraph">Colors: Rose gold, space gray, gold, silver</p>
  <p class="gb-paragraph">Model Identifier: MacBook10,1</p>
  ```

A page that yields no device at all still throws, so a layout change we cannot read fails loudly instead of silently emptying the data files.

Scope is the parser only. The `Promise.all` fragility — one bad page still aborts every other page — is left as follow-up.

## Verification

Ran the workflow on this branch: [run #205](https://github.com/kyle-seongwoo-jun/apple-device-identifiers/actions/runs/32922782212) — **all 49 page parses succeeded (7 products × 7 locales), 0 errors.**

| page | devices | | page | devices |
|---|---|---|---|---|
| 103257 MacBook (old layout) | 7 | | 102852 Mac mini | 14 |
| 102869 MacBook Air | 26 | | 102231 Mac Studio | 6 |
| 108052 MacBook Pro | 75 | | 102887 Mac Pro | 10 |
| 108054 iMac | 32 | | | |

Output was compared against the last known-good scrape (the `scrap/apple-websites` branch produced by run #196) for all seven locales: **144 identifiers each, nothing missing, nothing added, nothing renamed.** The one exception is `MacBookPro5,3` in zh-HK/zh-MO, where Apple itself changed `2.53GHz` to `2.53 GHz`.

The generated diff against `main` is exactly the M5 identifiers that have been waiting in #38 since June:

```
+  "Mac17,3": "MacBook Air (13-inch, M5)",
+  "Mac17,4": "MacBook Air (15-inch, M5)",
+  "Mac17,6": "MacBook Pro (16-inch, M5 Pro or M5 Max)",
+  "Mac17,7": "MacBook Pro (14-inch, M5 Pro or M5 Max)",
+  "Mac17,8": "MacBook Pro (16-inch, M5 Pro or M5 Max)",
+  "Mac17,9": "MacBook Pro (14-inch, M5 Pro or M5 Max)",
```

Two notes on how that run was done. The workflow was temporarily reduced to the scrape step for it, because `create-pull-request` would otherwise have rebuilt the `scrap/apple-websites` branch on top of this one and clobbered #38; that temporary commit is not part of this PR, and `.github/workflows/scrapper.yml` here is byte-identical to `main`. The run therefore also had no `OPENAI_API_KEY`, so the LLM conflict resolution in `mac-device-identifiers-unique.json` took its warn-only fallback path and is not covered by this verification.

`deno fmt --check` and `deno lint` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1dApAEGKuhAR1LAqHcMoP)_